### PR TITLE
fix(server): fix version retrieval

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -190,12 +190,11 @@ impl<'a> Uploader<'a> {
 
     /// Returns the server version.
     pub fn retrieve_version(&self) -> Result<String> {
-        let mut base = Url::parse(&self.config.server.address)?;
-        if base.path().to_string().chars().last().unwrap() != '/' {
-            let path = format!("{}/", base.path().to_string());
-            base = base.join(&path)?;
+        let mut url = Url::parse(&self.config.server.address)?;
+        if !url.path().to_string().ends_with("/") {
+            url = url.join(&format!("{}/", url.path().to_string()))?;
         }
-        let url = base.join("version")?;
+        url = url.join("version")?;
 
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -190,8 +190,13 @@ impl<'a> Uploader<'a> {
 
     /// Returns the server version.
     pub fn retrieve_version(&self) -> Result<String> {
-        let mut url = Url::parse(&self.config.server.address)?;
-        url.set_path("version");
+        let mut base = Url::parse(&self.config.server.address)?;
+        if base.path().to_string().chars().last().unwrap() != '/' {
+            let path = format!("{}/", base.path().to_string());
+            base = base.join(&path)?;
+        }
+        let url = base.join("version")?;
+
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {
             request = request.set("Authorization", auth_token);

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -191,8 +191,8 @@ impl<'a> Uploader<'a> {
     /// Returns the server version.
     pub fn retrieve_version(&self) -> Result<String> {
         let mut url = Url::parse(&self.config.server.address)?;
-        if !url.path().to_string().ends_with("/") {
-            url = url.join(&format!("{}/", url.path().to_string()))?;
+        if !url.path().to_string().ends_with('/') {
+            url = url.join(&format!("{}/", url.path()))?;
         }
         url = url.join("version")?;
 


### PR DESCRIPTION
Currently the version is retrieved from `example.com/version`, even, if the server is set to `example.com/paste/` or `example.com/paste`.
It should be retrieved from `example.com/paste/version`