### PR TITLE
feat(tls): support using the OS TLS trust store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           - { OS: ubuntu-latest, TARGET: "i686-unknown-linux-gnu" }
           - { OS: ubuntu-latest, TARGET: "i686-unknown-linux-musl" }
           # - { OS: ubuntu-latest, TARGET: "armv5te-unknown-linux-gnueabi" }
-          - { OS: ubuntu-latest, TARGET: "armv7-unknown-linux-gnueabihf" }
+          - {
+              OS: ubuntu-latest,
+              TARGET: "armv7-unknown-linux-gnueabihf"
+            }
           - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-gnu" }
           - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-musl" }
           - { OS: ubuntu-latest, TARGET: "x86_64-pc-windows-gnu" }
@@ -31,7 +34,8 @@ jobs:
           - { OS: macos-latest, TARGET: "aarch64-apple-darwin" }
           - { OS: windows-latest, TARGET: "x86_64-pc-windows-msvc" }
           - { OS: windows-latest, TARGET: "i686-pc-windows-msvc" }
-        TOOLCHAIN: [stable, beta, nightly]
+        TOOLCHAIN: [ stable, beta, nightly ]
+        FEATURES: [ "", "--features use-native-certs" ]
 
     steps:
       - name: Checkout the repository
@@ -53,7 +57,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.config.TARGET }}
+          args: --target ${{ matrix.config.TARGET }} ${{ matrix.FEATURES }}
 
       - name: Check formatting
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build for ${{ matrix.config.TARGET }} using Rust ${{ matrix.TOOLCHAIN }} (on ${{ matrix.config.OS }})
+    name: "Build for ${{ matrix.config.TARGET }} using Rust ${{ matrix.TOOLCHAIN }} (on ${{ matrix.config.OS }}) [args: ${{ matrix.BUILD_ARGS }}]"
     runs-on: ${{ matrix.config.OS }}
     strategy:
       fail-fast: false
@@ -35,7 +35,7 @@ jobs:
           - { OS: windows-latest, TARGET: "x86_64-pc-windows-msvc" }
           - { OS: windows-latest, TARGET: "i686-pc-windows-msvc" }
         TOOLCHAIN: [ stable, beta, nightly ]
-        FEATURES: [ "", "--features use-native-certs" ]
+        BUILD_ARGS: [ "", "--features use-native-certs" ]
 
     steps:
       - name: Checkout the repository
@@ -57,7 +57,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.config.TARGET }} ${{ matrix.FEATURES }}
+          args: --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
 
       - name: Check formatting
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -346,6 +362,12 @@ name = "once_cell"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "percent-encoding"
@@ -484,6 +506,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +569,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -700,6 +775,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "rustls-webpki",
  "url",
  "webpki-roots",
@@ -730,9 +806,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -740,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -755,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -765,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -778,15 +854,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -822,6 +898,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ toml = "0.7.4"
 dirs-next = "2.0.0"
 thiserror = "1.0.40"
 getopts = "0.2.21"
-ureq = "2.7.1"
+ureq = { version = "2.7.1", default-features = true, features = ["native-certs"] }
 multipart = { version = "0.18.0", default-features = false, features = [
   "client",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,17 @@ default-run = "rpaste"
 name = "rpaste"
 path = "src/main.rs"
 
+[features]
+default = []
+use-native-certs = ["ureq/native-certs"]
+
 [dependencies]
 serde = { version = "1.0.164", default-features = false, features = ["derive"] }
 toml = "0.7.4"
 dirs-next = "2.0.0"
 thiserror = "1.0.40"
 getopts = "0.2.21"
-ureq = { version = "2.7.1", default-features = true, features = ["native-certs"] }
+ureq = "2.7.1"
 multipart = { version = "0.18.0", default-features = false, features = [
   "client",
 ] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ A CLI tool for [**rustypaste**](https://github.com/orhun/rustypaste).
 cargo install rustypaste-cli
 ```
 
+#### Features
+
+- `use-native-certs`: makes the default TLS implementation use the OS' trust store. [\*](https://github.com/algesten/ureq#https--tls--ssl) (disabled)
+
+To enable crate features, use the `--features` flag as follows:
+
+```sh
+cargo install rustypaste-cli --features use-native-certs
+```
+
 ### Arch Linux
 
 ```


### PR DESCRIPTION
This is usually the preferred way. OSes keep the root CAs more recent and it makes it possible to use self-signed certs as well.

closes #14