### PR TITLE
feat(cli): automatically detect if the data is piped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.1",
  "rustix 0.38.2",
@@ -587,6 +587,7 @@ dependencies = [
  "dirs-next",
  "getopts",
  "indicatif",
+ "is-terminal",
  "multipart",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +220,15 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -261,7 +281,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -272,7 +292,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
@@ -562,6 +582,7 @@ dependencies = [
 name = "rustypaste-cli"
 version = "0.5.0"
 dependencies = [
+ "atty",
  "colored",
  "dirs-next",
  "getopts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,15 +209,6 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -281,7 +261,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -292,7 +272,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
@@ -582,7 +562,6 @@ dependencies = [
 name = "rustypaste-cli"
 version = "0.5.0"
 dependencies = [
- "atty",
  "colored",
  "dirs-next",
  "getopts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ multipart = { version = "0.18.0", default-features = false, features = [
 colored = "2.0.4"
 url = "2.4.0"
 indicatif = "0.17.5"
-atty = "0.2.14"
 is-terminal = "0.4.9"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ multipart = { version = "0.18.0", default-features = false, features = [
 colored = "2.0.4"
 url = "2.4.0"
 indicatif = "0.17.5"
+atty = "0.2.14"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ colored = "2.0.4"
 url = "2.4.0"
 indicatif = "0.17.5"
 atty = "0.2.14"
+is-terminal = "0.4.9"
 
 [profile.release]
 opt-level = 3

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
-use is_terminal::IsTerminal;
 use getopts::Options;
+use is_terminal::IsTerminal;
 use std::env;
 use std::path::PathBuf;
 use std::process;

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,4 @@
+use atty::{is, Stream};
 use getopts::Options;
 use std::env;
 use std::path::PathBuf;
@@ -68,7 +69,8 @@ impl Args {
                 && !matches.opt_present("u")
                 && !matches.opt_present("r")
                 && !matches.opt_present("V")
-                && !matches.opt_present("v"))
+                && !matches.opt_present("v")
+                && is(Stream::Stdin))
         {
             let usage = format!(
                 "\n{} {} \u{2014} {}.\

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use atty::{is, Stream};
+use is_terminal::IsTerminal;
 use getopts::Options;
 use std::env;
 use std::path::PathBuf;
@@ -70,7 +70,7 @@ impl Args {
                 && !matches.opt_present("r")
                 && !matches.opt_present("V")
                 && !matches.opt_present("v")
-                && is(Stream::Stdin))
+                && std::io::stdin().is_terminal())
         {
             let usage = format!(
                 "\n{} {} \u{2014} {}.\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::args::Args;
 use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
-use atty::{isnt, Stream};
+use is_terminal::IsTerminal;
 use colored::Colorize;
 use std::fs;
 use std::io::{self, Read};
@@ -59,7 +59,7 @@ pub fn run(args: Args) -> Result<()> {
         results.push(uploader.upload_url(url));
     } else if let Some(ref remote_url) = args.remote {
         results.push(uploader.upload_remote_url(remote_url));
-    } else if isnt(Stream::Stdin) || args.files.contains(&String::from("-")) {
+    } else if !std::io::stdin().is_terminal() || args.files.contains(&String::from("-")) {
         let mut buffer = Vec::new();
         let stdin = io::stdin();
         for bytes in stdin.bytes() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ use crate::args::Args;
 use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
-use is_terminal::IsTerminal;
 use colored::Colorize;
+use is_terminal::IsTerminal;
 use std::fs;
 use std::io::{self, Read};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use crate::args::Args;
 use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
+use atty::{isnt, Stream};
 use colored::Colorize;
 use std::fs;
 use std::io::{self, Read};
@@ -58,7 +59,7 @@ pub fn run(args: Args) -> Result<()> {
         results.push(uploader.upload_url(url));
     } else if let Some(ref remote_url) = args.remote {
         results.push(uploader.upload_remote_url(remote_url));
-    } else if args.files.contains(&String::from("-")) {
+    } else if isnt(Stream::Stdin) || args.files.contains(&String::from("-")) {
         let mut buffer = Vec::new();
         let stdin = io::stdin();
         for bytes in stdin.bytes() {


### PR DESCRIPTION
When data is piped into `rpaste`, there is no reason having to add `-` as a file.

Before:

```
cat whatever.txt |rpaste -
```

After:

```
cat whatever.txt |rpaste
```

When running `rpaste` without data being piped to it, a `-` is still required for reading from stdin.