### PR TITLE
style(cli): remove extra newline from version output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let uploader = Uploader::new(&config);
     if args.print_server_version {
-        println!("rustypaste-server {}", uploader.retrieve_version()?);
+        println!("rustypaste-server {}", uploader.retrieve_version()?.trim());
         return Ok(());
     }
 


### PR DESCRIPTION
Due to https://github.com/orhun/rustypaste/pull/97 the `-V` argument now prints an extra newline.

This PR removes the extra newline character.

# Before

```
[tessus@epsilon3 0 ~/data/tmp/rptest]$ rpaste -s https://rptest.local/paste -V -a token
rustypaste-server 0.11.1

[tessus@epsilon3 0 ~/data/tmp/rptest]$
```

# After

This is how it looked before https://github.com/orhun/rustypaste/pull/97 

```
[tessus@epsilon3 0 ~/data/tmp/rptest]$ rpaste -s https://rptest.local/paste -V -a token
rustypaste-server 0.11.1
[tessus@epsilon3 0 ~/data/tmp/rptest]$
```
