### PR TITLE
feat(cli): add option to delete file(s) from server

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ cargo build --release
 -v, --version        prints version information
 -V, --server-version retrieves the server version
 -l, --list           lists files on the server
+-d, --delete         delete files from server
 -o, --oneshot        generates one shot links
 -p, --pretty         prettifies the output
 -c, --config CONFIG  sets the configuration file
 -s, --server SERVER  sets the address of the rustypaste server
--a, --auth TOKEN     sets the authentication token
+-a, --auth TOKEN     sets the authentication or delete token
 -u, --url URL        sets the URL to shorten
 -r, --remote URL     sets the remote URL for uploading
 -e, --expire TIME    sets the expiration time for the link
@@ -132,6 +133,12 @@ rpaste -l
 ```
 
 \* Use `-p` for table output instead of JSON.
+
+### Delete files from server
+
+```sh
+rpaste -d awesome.UA86.txt other.JSNI.txt
+```
 
 ### Extras
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 [server]
 address = "https://paste.example.com"
 #auth_token = ""
+#delete_token = ""
 
 [paste]
 oneshot = false

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,7 +11,7 @@ pub struct Args {
     pub config: Option<PathBuf>,
     /// Server address.
     pub server: Option<String>,
-    /// Authentication token.
+    /// Authentication or delete token.
     pub auth: Option<String>,
     /// URL to shorten.
     pub url: Option<String>,
@@ -51,7 +51,12 @@ impl Args {
             "sets the address of the rustypaste server",
             "SERVER",
         );
-        opts.optopt("a", "auth", "sets the authentication token", "TOKEN");
+        opts.optopt(
+            "a",
+            "auth",
+            "sets the authentication or delete token",
+            "TOKEN",
+        );
         opts.optopt("u", "url", "sets the URL to shorten", "URL");
         opts.optopt("r", "remote", "sets the remote URL for uploading", "URL");
         opts.optopt(

--- a/src/args.rs
+++ b/src/args.rs
@@ -29,6 +29,8 @@ pub struct Args {
     pub print_server_version: bool,
     /// List files on the server (file name, file size, expiry timestamp).
     pub list_files: bool,
+    /// Delete files from server.
+    pub delete: bool,
 }
 
 impl Args {
@@ -39,6 +41,7 @@ impl Args {
         opts.optflag("v", "version", "prints version information");
         opts.optflag("V", "server-version", "retrieves the server version");
         opts.optflag("l", "list", "lists files on the server");
+        opts.optflag("d", "delete", "delete files from server");
         opts.optflag("o", "oneshot", "generates one shot links");
         opts.optflag("p", "pretty", "prettifies the output");
         opts.optopt("c", "config", "sets the configuration file", "CONFIG");
@@ -73,6 +76,7 @@ impl Args {
                 && !matches.opt_present("r")
                 && !matches.opt_present("V")
                 && !matches.opt_present("l")
+                && !matches.opt_present("d")
                 && !matches.opt_present("v")
                 && std::io::stdin().is_terminal())
         {
@@ -111,6 +115,7 @@ impl Args {
             prettify: matches.opt_present("p"),
             print_server_version: matches.opt_present("V"),
             list_files: matches.opt_present("l"),
+            delete: matches.opt_present("d"),
             files: matches.free,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct ServerConfig {
     pub address: String,
     /// Token for authentication.
     pub auth_token: Option<String>,
+    /// Token for deleting files.
+    pub delete_token: Option<String>,
 }
 
 /// Paste configuration.
@@ -45,6 +47,9 @@ impl Config {
         }
         if args.auth.is_some() {
             self.server.auth_token = args.auth.as_ref().cloned();
+            if args.delete {
+                self.server.delete_token = args.auth.as_ref().cloned();
+            }
         }
         if args.oneshot {
             self.paste.oneshot = Some(true);

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
     /// Error that might occur while uploading files.
     #[error("Upload error: `{0}`")]
     UploadError(String),
+    /// Error that might occur while deleting files from server.
+    #[error("Delete error: `{0}`")]
+    DeleteError(String),
     /// Error that might occur when no server address is provided.
     #[error("No rustypaste server address is given.")]
     NoServerAddressError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,11 @@ pub fn run(args: Args) -> Result<()> {
         results.push(uploader.upload_stream(&*buffer));
     } else {
         for file in args.files.iter() {
-            results.push(uploader.upload_file(file))
+            if !args.delete {
+                results.push(uploader.upload_file(file))
+            } else {
+                results.push(uploader.delete_file(file))
+            }
         }
     }
     let prettify = args.prettify

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -215,8 +215,9 @@ impl<'a> Uploader<'a> {
         let result = match request.call() {
             Ok(response) => {
                 let status = response.status();
+                let response_text = response.into_string()?;
                 if status == 200 {
-                    Ok("Deleted".to_string())
+                    Ok(response_text)
                 } else {
                     Err(Error::DeleteError(format!(
                         "unknown error (status code: {status})"


### PR DESCRIPTION
add support for https://github.com/orhun/rustypaste/pull/136

The `delete_token` in the config file can be overwritten on the command line with `-a <delete_token>`.
auth and delete tokens are mutually exclusive, thus I didn't create a separate option for the delete token, but just reused the existing one (`-a`).

# normal output

```
$ rpaste -s https://rptest.local/paste README.md
https://rptest.local/paste/README.JSNI.md
$ rpaste -s https://rptest.local/paste README.md -lp
     Name      | Size |    Expiry (UTC)
---------------|------|--------------------
README.JSNI.md | 3957 | 2023-09-03 21:38:56

$ rpaste -s https://rptest.local/paste -d README.JSNI.md
Deleted

$ rpaste -s https://rptest.local/paste -d README.JSNI.md
Delete error: `file is not found or expired :(`
```

# pretty output

```
$ rpaste -s https://rptest.local/paste README.md
https://rptest.local/paste/README.UA86.md
$ rpaste -s https://rptest.local/paste README.md -lp
     Name      | Size |    Expiry (UTC)
---------------|------|--------------------
README.UA86.md | 3957 | 2023-09-03 21:39:52

$ rpaste -s https://rptest.local/paste -d README.UA86.md -p
README.UA86.md => Deleted

$ rpaste -s https://rptest.local/paste -d README.UA86.md -p
README.UA86.md => Delete error: `file is not found or expired :(`
```