### PR TITLE
refactor(cli): use IsTerminal from stdlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,6 @@ dependencies = [
  "dirs-next",
  "getopts",
  "indicatif",
- "is-terminal",
  "multipart",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ multipart = { version = "0.18.0", default-features = false, features = [
 colored = "2.0.4"
 url = "2.4.1"
 indicatif = "0.17.6"
-is-terminal = "0.4.9"
 
 [profile.release]
 opt-level = 3

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use getopts::Options;
-use is_terminal::IsTerminal;
 use std::env;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
 use colored::Colorize;
-use is_terminal::IsTerminal;
 use std::fs;
+use std::io::IsTerminal;
 use std::io::{self, Read};
 
 /// Default name of the configuration file.


### PR DESCRIPTION
As of Rust 1.70, most users should use the [IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) trait in the Rust standard library instead of the is-terminal crate.

This change removes the crate and uses the stdlib now. I've tested the change manually.

Follow-up to #28 (see https://github.com/orhun/rustypaste-cli/pull/28#issuecomment-1627475564)