### PR TITLE
feat(cli): add argument to specify filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ rpaste -d awesome.UA86.txt other.JSNI.txt
 rpaste -n filename-on-server.txt awesome.txt
 ```
 
-\* rustypaste 0.15.0 is required for this argument to work, otherwise the filename will not be overridden.
+\* rustypaste >=0.15.0 is required for this argument to work, otherwise the filename will not be overridden.
 
 ### Extras
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cargo build --release
 -u, --url URL        sets the URL to shorten
 -r, --remote URL     sets the remote URL for uploading
 -e, --expire TIME    sets the expiration time for the link
+-n, --filename NAME  sets and overrides the filename
 ```
 
 ### Set credentials
@@ -138,6 +139,12 @@ rpaste -l
 
 ```sh
 rpaste -d awesome.UA86.txt other.JSNI.txt
+```
+
+### Override the filename
+
+```sh
+rpaste -n filename-on-server.txt awesome.txt
 ```
 
 ### Extras

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ rpaste -d awesome.UA86.txt other.JSNI.txt
 rpaste -n filename-on-server.txt awesome.txt
 ```
 
+\* rustypaste 0.15.0 is required for this argument to work, otherwise the filename will not be overridden.
+
 ### Extras
 
 - Show a _prettier_ output: `rpaste -p [...]`

--- a/src/args.rs
+++ b/src/args.rs
@@ -31,6 +31,8 @@ pub struct Args {
     pub list_files: bool,
     /// Delete files from server.
     pub delete: bool,
+    /// Send filename header (give uploaded file a specific name).
+    pub filename: Option<String>,
 }
 
 impl Args {
@@ -65,6 +67,7 @@ impl Args {
             "sets the expiration time for the link",
             "TIME",
         );
+        opts.optopt("n", "filename", "specify filename header", "NAME");
 
         let env_args: Vec<String> = env::args().collect();
         let matches = match opts.parse(&env_args[1..]) {
@@ -121,6 +124,7 @@ impl Args {
             print_server_version: matches.opt_present("V"),
             list_files: matches.opt_present("l"),
             delete: matches.opt_present("d"),
+            filename: matches.opt_str("n"),
             files: matches.free,
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -67,7 +67,7 @@ impl Args {
             "sets the expiration time for the link",
             "TIME",
         );
-        opts.optopt("n", "filename", "specify filename header", "NAME");
+        opts.optopt("n", "filename", "sets and overrides the filename", "NAME");
 
         let env_args: Vec<String> = env::args().collect();
         let matches = match opts.parse(&env_args[1..]) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct PasteConfig {
     pub oneshot: Option<bool>,
     /// Expiration time for the link.
     pub expire: Option<String>,
+    /// Filename.
+    #[serde(skip_deserializing)]
+    pub filename: Option<String>,
 }
 
 /// Style configuration.
@@ -56,6 +59,9 @@ impl Config {
         }
         if args.expire.is_some() {
             self.paste.expire = args.expire.as_ref().cloned();
+        }
+        if args.filename.is_some() {
+            self.paste.filename = args.filename.as_ref().cloned();
         }
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -15,6 +15,9 @@ const DEFAULT_FILE_NAME: Option<&str> = Some("file");
 /// HTTP header to use for specifying expiration times.
 const EXPIRATION_HEADER: &str = "expire";
 
+/// HTTP header for specifying the filename.
+const FILENAME_HEADER: &str = "filename";
+
 /// File entry item for list endpoint.
 #[derive(Deserialize, Debug)]
 pub struct ListItem {
@@ -164,6 +167,9 @@ impl<'a> Uploader<'a> {
         }
         if let Some(expiration_time) = &self.config.paste.expire {
             request = request.set(EXPIRATION_HEADER, expiration_time);
+        }
+        if let Some(filename) = &self.config.paste.filename {
+            request = request.set(FILENAME_HEADER, filename);
         }
         let progress_bar = ProgressBar::new_spinner();
         progress_bar.enable_steady_tick(Duration::from_millis(80));


### PR DESCRIPTION
Add argument:

```
    -n, --filename NAME sets and overrides the filename
```

Example:

```bash
rpaste -n filename-on-server.txt awesome.txt
```

closes #82 