### PR TITLE
refactor(ci): split workflow into stable and beta/nightly

### DIFF
--- a/.github/workflows/ci-beta-nightly.yml
+++ b/.github/workflows/ci-beta-nightly.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build-beta-nightly:

--- a/.github/workflows/ci-beta-nightly.yml
+++ b/.github/workflows/ci-beta-nightly.yml
@@ -24,7 +24,7 @@ jobs:
             }
           - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-gnu" }
           - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-musl" }
-          - { OS: ubuntu-latest, TARGET: "x86_64-pc-windows-gnu" }
+          # - { OS: ubuntu-latest, TARGET: "x86_64-pc-windows-gnu" }
           - { OS: macos-latest, TARGET: "x86_64-apple-darwin" }
           - { OS: macos-latest, TARGET: "aarch64-apple-darwin" }
           - { OS: windows-latest, TARGET: "x86_64-pc-windows-msvc" }

--- a/.github/workflows/ci-beta-nightly.yml
+++ b/.github/workflows/ci-beta-nightly.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-beta-nightly:

--- a/.github/workflows/ci-beta-nightly.yml
+++ b/.github/workflows/ci-beta-nightly.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Build Test (Beta and Nightly)
 
 on:
   push:
@@ -7,11 +7,9 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * 0"
 
 jobs:
-  build:
+  build-beta-nightly:
     name: "Build for ${{ matrix.config.TARGET }} using Rust ${{ matrix.TOOLCHAIN }} (on ${{ matrix.config.OS }}) [args: ${{ matrix.BUILD_ARGS }}]"
     runs-on: ${{ matrix.config.OS }}
     strategy:
@@ -34,7 +32,7 @@ jobs:
           - { OS: macos-latest, TARGET: "aarch64-apple-darwin" }
           - { OS: windows-latest, TARGET: "x86_64-pc-windows-msvc" }
           - { OS: windows-latest, TARGET: "i686-pc-windows-msvc" }
-        TOOLCHAIN: [ stable ]
+        TOOLCHAIN: [ beta, nightly ]
         BUILD_ARGS: [ "", "--features use-native-certs" ]
 
     steps:
@@ -58,26 +56,3 @@ jobs:
           use-cross: true
           command: build
           args: --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
-
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Check lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
-  audit:
-    name: Perform audit for security
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-      - name: Run cargo-audit
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-beta-nightly.yml
+++ b/.github/workflows/ci-beta-nightly.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-beta-nightly:
-    name: "Build for ${{ matrix.config.TARGET }} using Rust ${{ matrix.TOOLCHAIN }} (on ${{ matrix.config.OS }}) [args: ${{ matrix.BUILD_ARGS }}]"
+    name: "Build for ${{ matrix.config.TARGET }} (on ${{ matrix.config.OS }}) [args: ${{ matrix.BUILD_ARGS }}]"
     runs-on: ${{ matrix.config.OS }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
+        run: cross build --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
 
       - name: Check formatting
         run: cargo fmt -- --check --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
           target: ${{ matrix.config.TARGET }}
           components: rustfmt, clippy
 
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: Install cross
+        uses: taiki-e/install-action@cross
 
       - name: Build
         run: cross build --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,34 +42,26 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.TOOLCHAIN }}
           target: ${{ matrix.config.TARGET }}
-          override: true
           components: rustfmt, clippy
+
+      - name: Install cross
+        uses: taiki-e/install-action@cross
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
+        run: cargo build --target ${{ matrix.config.TARGET }} ${{ matrix.BUILD_ARGS }}
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt -- --check --verbose
 
       - name: Check lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy --tests --verbose -- -D warnings
 
   audit:
     name: Perform audit for security
@@ -78,6 +70,6 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Run cargo-audit
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change splits the workflow into 2 parts:

- stable
- beta and nightly

The `build` job should be added to the branch protection rule of the master branch. But I cannot do that. orhun, you will have to set that up. 