### PR TITLE
fix(upload): omit explicit lifetime

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -69,7 +69,7 @@ impl<'a, R: Read> UploadTracker<'a, R> {
     }
 }
 
-impl<'a, R: Read> Read for UploadTracker<'a, R> {
+impl<R: Read> Read for UploadTracker<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         let bytes_read = self.inner.read(buf)?;
         self.uploaded += bytes_read;


### PR DESCRIPTION
clippy throws an error in CI:

```
error: the following explicit lifetimes could be elided: 'a
  --> src/upload.rs:72:6
   |
72 | impl<'a, R: Read> Read for UploadTracker<'a, R> {
   |      ^^                                  ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
   |
72 - impl<'a, R: Read> Read for UploadTracker<'a, R> {
72 + impl<R: Read> Read for UploadTracker<'_, R> {
   |

error: could not compile `rustypaste-cli` (lib) due to 1 previous error
```