### PR TITLE
fix(list): panic when creation_date_utc is null

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -26,14 +26,9 @@ pub struct ListItem {
     /// Size of the file in bytes.
     pub file_size: u64,
     /// ISO8601 formatted date-time string of the creation timestamp.
-    #[serde(default = "creation_date_utc_default")]
-    pub creation_date_utc: String,
+    pub creation_date_utc: Option<String>,
     /// ISO8601 formatted date-time string of the expiration timestamp if one exists for this file.
     pub expires_at_utc: Option<String>,
-}
-
-fn creation_date_utc_default() -> String {
-    "info not available".to_string()
 }
 
 /// Wrapper around raw data and result.
@@ -328,12 +323,11 @@ impl<'a> Uploader<'a> {
                 "{:<filename_width$} | {:>filesize_width$} | {:<19} | {}",
                 file_info.file_name,
                 file_info.file_size,
-                file_info.creation_date_utc,
                 file_info
-                    .expires_at_utc
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_default()
+                    .creation_date_utc
+                    .as_deref()
+                    .unwrap_or("info not available"),
+                file_info.expires_at_utc.as_deref().unwrap_or_default()
             )
         })?;
         Ok(())


### PR DESCRIPTION
I was trying `rpaste -l` and found that it panics.

After some digging, I found that the code used the `serde(default)` macro to set a default value for the creation date when it's not available.

As [this issue of serde](https://github.com/serde-rs/serde/issues/1098) points out, the macro is only useful when the field is undefined (instead of null), so it cannot be used here.

Note: I'm using a musl build of the rustypaste server, and it always returns null for the creation date.
