### PR TITLE
feat(cli): honor XDG_CONFIG_HOME on macOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ impl Config {
     }
 
     /// Find a special config path on macOS.
-    /// 
+    ///
     /// The `dirs-next` crate ignores the `XDG_CONFIG_HOME` env var on macOS and only considers
     /// `Library/Application Support` as the config dir, which is primarily used by GUI apps.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,12 +97,15 @@ impl Config {
         };
     }
 
-    // The dirs-next crate ignores the XDG_CONFIG_HOME env var on macOS and only considers
-    // `Library/Application Support` as the config dir, which is primarily used by GUI apps.
-    // This function determines the config path and honors the XDG_CONFIG_HOME env var.
-    // If it is not set, it will fall back to `~/.config`
+    /// Find a special config path on macOS.
+    /// 
+    /// The `dirs-next` crate ignores the `XDG_CONFIG_HOME` env var on macOS and only considers
+    /// `Library/Application Support` as the config dir, which is primarily used by GUI apps.
+    ///
+    /// This function determines the config path and honors the `XDG_CONFIG_HOME` env var.
+    /// If it is not set, it will fall back to `~/.config`
     #[cfg(target_os = "macos")]
-    pub(crate) fn determine_config_dir_on_macos_honoring_xdg_config_path(&self) -> PathBuf {
+    pub(crate) fn retrieve_xdg_config_on_macos(&self) -> PathBuf {
         let config_dir = env::var("XDG_CONFIG_HOME").map_or_else(
             |_| dirs_next::home_dir().unwrap_or_default().join(".config"),
             PathBuf::from,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,22 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
 use colored::Colorize;
+use std::env;
 use std::fs;
 use std::io::IsTerminal;
 use std::io::{self, Read};
+use std::path::PathBuf;
 
 /// Default name of the configuration file.
 const CONFIG_FILE: &str = "config.toml";
+
+fn config_dir_helper() -> PathBuf {
+    let config_dir = env::var("XDG_CONFIG_HOME").map_or_else(
+        |_| dirs_next::home_dir().unwrap_or_default().join(".config"),
+        PathBuf::from,
+    );
+    config_dir.join("rustypaste")
+}
 
 /// Runs `rpaste`.
 pub fn run(args: Args) -> Result<()> {
@@ -32,6 +42,7 @@ pub fn run(args: Args) -> Result<()> {
     } else {
         for path in [
             dirs_next::home_dir().map(|p| p.join(".rustypaste").join(CONFIG_FILE)),
+            Some(config_dir_helper().join(CONFIG_FILE)),
             dirs_next::config_dir().map(|p| p.join("rustypaste").join(CONFIG_FILE)),
         ]
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,22 +17,12 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use crate::upload::Uploader;
 use colored::Colorize;
-use std::env;
 use std::fs;
 use std::io::IsTerminal;
 use std::io::{self, Read};
-use std::path::PathBuf;
 
 /// Default name of the configuration file.
 const CONFIG_FILE: &str = "config.toml";
-
-fn config_dir_helper() -> PathBuf {
-    let config_dir = env::var("XDG_CONFIG_HOME").map_or_else(
-        |_| dirs_next::home_dir().unwrap_or_default().join(".config"),
-        PathBuf::from,
-    );
-    config_dir.join("rustypaste")
-}
 
 /// Runs `rpaste`.
 pub fn run(args: Args) -> Result<()> {
@@ -42,7 +32,12 @@ pub fn run(args: Args) -> Result<()> {
     } else {
         for path in [
             dirs_next::home_dir().map(|p| p.join(".rustypaste").join(CONFIG_FILE)),
-            Some(config_dir_helper().join(CONFIG_FILE)),
+            #[cfg(target_os = "macos")]
+            Some(
+                config
+                    .determine_config_dir_on_macos_honoring_xdg_config_path()
+                    .join(CONFIG_FILE),
+            ),
             dirs_next::config_dir().map(|p| p.join("rustypaste").join(CONFIG_FILE)),
         ]
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,7 @@ pub fn run(args: Args) -> Result<()> {
         for path in [
             dirs_next::home_dir().map(|p| p.join(".rustypaste").join(CONFIG_FILE)),
             #[cfg(target_os = "macos")]
-            Some(
-                config
-                    .determine_config_dir_on_macos_honoring_xdg_config_path()
-                    .join(CONFIG_FILE),
-            ),
+            Some(config.retrieve_xdg_config_on_macos().join(CONFIG_FILE)),
             dirs_next::config_dir().map(|p| p.join("rustypaste").join(CONFIG_FILE)),
         ]
         .iter()


### PR DESCRIPTION
I've tested it manually on macOS and it works splendidly.

So now on macOS the rustypaste config file can be in the following directories:

- `$HOME/.rustypaste`
- `$HOME/.config/rustypaste`
- `$XDG_CONFIG_HOME/rustypaste`
- `$HOME/Library/Application Support/rustypaste`

closes #184 