### PR TITLE
chore(release): prepare for v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2025-04-25
+
+### Added
+
+- Honor XDG_CONFIG_HOME on macOS by @tessus in [#185](https://github.com/orhun/rustypaste-cli/pull/185)
+
+### Fixed
+
+- No panic when creation_date_utc is null by @musl in [#182](https://github.com/orhun/rustypaste-cli/pull/182)
+
+### Changed
+
+- Bump dependencies
+
 ## [0.9.3] - 2025-03-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Honor XDG_CONFIG_HOME on macOS by @tessus in [#185](https://github.com/orhun/rustypaste-cli/pull/185)
+- Honor XDG_CONFIG_HOME on macOS (additionally search for the config file at the same locations as on Linux) by @tessus in [#185](https://github.com/orhun/rustypaste-cli/pull/185)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "rustypaste-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "colored",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustypaste-cli"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 description = "A CLI tool for rustypaste"
 authors = ["Orhun Parmaksız <orhunparmaksiz@gmail.com>"]

--- a/man/rpaste.1
+++ b/man/rpaste.1
@@ -1,6 +1,6 @@
 .\" Manpage for rpaste
 
-.TH RPASTE "1" "Mar 2025" "rustypaste-cli 0.9.3" "User Commands"
+.TH RPASTE "1" "Apr 2025" "rustypaste-cli 0.9.4" "User Commands"
 .SH NAME
 .PP
 rpaste \- a CLI tool for rustypaste


### PR DESCRIPTION
Cutting a new release is not highly involved, so I don't see an issue to create them even w/o major improvements.

Although in this case I would argue that fixing a panic and allowing a config file in `~/.config` or `XDG_CONFIG_DIR` warrants a release.