### PR TITLE
fix(http): migrate to ureq 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade ureq to 3.3.0
+
 ## [0.9.5] - 2026-03-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -28,15 +22,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -75,10 +75,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
+name = "cookie"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -86,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -98,6 +127,12 @@ checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "dirs"
@@ -129,6 +164,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -213,6 +257,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -403,7 +463,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall",
 ]
@@ -421,10 +481,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
-name = "log"
-version = "0.4.21"
+name = "litrs"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -465,6 +537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,9 +550,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -493,6 +571,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -588,7 +672,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -612,25 +696,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
-dependencies = [
- "base64 0.21.7",
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -662,6 +735,7 @@ dependencies = [
  "getopts",
  "indicatif",
  "multipart",
+ "rustls-native-certs",
  "serde",
  "shellexpand",
  "thiserror 2.0.18",
@@ -669,12 +743,6 @@ dependencies = [
  "ureq",
  "url",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schannel"
@@ -687,11 +755,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -700,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -740,13 +808,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -866,6 +936,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,21 +1049,34 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
+ "cookie_store",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "url",
+ "ureq-proto",
+ "utf8-zero",
  "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -983,6 +1096,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1069,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1313,3 +1432,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,15 @@ path = "src/main.rs"
 
 [features]
 default = []
-use-native-certs = ["ureq/native-certs"]
+use-native-certs = ["dep:rustls-native-certs"]
 
 [dependencies]
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 toml = "1.1.2"
 thiserror = "2.0.18"
 getopts = "0.2.24"
-ureq = { version = "2.12.1", features = ["json"] }
+ureq = { version = "3.3.0", features = ["json"] }
+rustls-native-certs = { version = "0.8.4", optional = true }
 multipart = { version = "0.18.0", default-features = false, features = [
   "client",
 ] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     TomlError(#[from] toml::de::Error),
     /// Error that might occur while processing/sending requests.
     #[error("Request error: `{0}`")]
-    RequestError(#[from] Box<ureq::Error>),
+    RequestError(#[from] ureq::Error),
     /// Error that might occur while uploading files.
     #[error("Upload error: `{0}`")]
     UploadError(String),

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -5,8 +5,9 @@ use multipart::client::lazy::Multipart;
 use serde::Deserialize;
 use std::io::{Read, Result as IoResult, Write};
 use std::time::Duration;
-use ureq::Error as UreqError;
-use ureq::{Agent, AgentBuilder};
+#[cfg(feature = "use-native-certs")]
+use ureq::tls::{Certificate, RootCerts, TlsConfig};
+use ureq::{Agent, SendBody};
 use url::Url;
 
 /// Default file name to use for multipart stream.
@@ -93,14 +94,16 @@ pub struct Uploader<'a> {
 impl<'a> Uploader<'a> {
     /// Constructs a new instance.
     pub fn new(config: &'a Config) -> Self {
+        let client_config = Agent::config_builder().user_agent(format!(
+            "{}/{}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        ));
+        #[cfg(feature = "use-native-certs")]
+        let client_config =
+            client_config.tls_config(TlsConfig::builder().root_certs(native_root_certs()).build());
         Self {
-            client: AgentBuilder::new()
-                .user_agent(&format!(
-                    "{}/{}",
-                    env!("CARGO_PKG_NAME"),
-                    env!("CARGO_PKG_VERSION")
-                ))
-                .build(),
+            client: client_config.build().into(),
             config,
         }
     }
@@ -162,42 +165,54 @@ impl<'a> Uploader<'a> {
     /// Uploads the given multipart data.
     fn upload(&self, mut multipart: Multipart<'static, '_>) -> Result<String> {
         let multipart_data = multipart.prepare()?;
-        let mut request = self.client.post(&self.config.server.address).set(
-            "Content-Type",
-            &format!(
-                "multipart/form-data; boundary={}",
-                multipart_data.boundary()
-            ),
-        );
+        let mut request = self
+            .client
+            .post(&self.config.server.address)
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header(
+                "Content-Type",
+                format!(
+                    "multipart/form-data; boundary={}",
+                    multipart_data.boundary()
+                ),
+            );
         if let Some(content_len) = multipart_data.content_len() {
-            request = request.set("Content-Length", &content_len.to_string());
+            request = request.header("Content-Length", content_len.to_string());
         }
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.set("Authorization", auth_token);
+            request = request.header("Authorization", auth_token);
         }
         if let Some(expiration_time) = &self.config.paste.expire {
-            request = request.set(EXPIRATION_HEADER, expiration_time);
+            request = request.header(EXPIRATION_HEADER, expiration_time);
         }
         if let Some(filename) = &self.config.paste.filename {
-            request = request.set(FILENAME_HEADER, filename);
+            request = request.header(FILENAME_HEADER, filename);
         }
         let progress_bar = ProgressBar::new_spinner();
         progress_bar.enable_steady_tick(Duration::from_millis(80));
         progress_bar.set_message("Uploading");
-        let upload_tracker = UploadTracker::new(
+        let mut upload_tracker = UploadTracker::new(
             &progress_bar,
             multipart_data.content_len().unwrap_or_default(),
             multipart_data,
         )?;
-        let result = match request.send(upload_tracker) {
+        let result = match request.send(SendBody::from_reader(&mut upload_tracker)) {
             Ok(response) => {
                 let status = response.status();
-                let response_text = response.into_string()?;
-                if response_text.lines().count() != 1 {
+                let response_text = response.into_body().read_to_string()?;
+                if status.is_client_error() || status.is_server_error() {
+                    Err(Error::UploadError(format!(
+                        "{} (status code: {})",
+                        response_text.trim(),
+                        status.as_u16()
+                    )))
+                } else if response_text.lines().count() != 1 {
                     Err(Error::UploadError(format!(
                         "server returned invalid body (status code: {status})"
                     )))
-                } else if status == 200 {
+                } else if status.as_u16() == 200 {
                     Ok(response_text)
                 } else {
                     Err(Error::UploadError(format!(
@@ -205,12 +220,7 @@ impl<'a> Uploader<'a> {
                     )))
                 }
             }
-            Err(UreqError::Status(code, response)) => Err(Error::UploadError(format!(
-                "{} (status code: {})",
-                response.into_string()?.trim(),
-                code
-            ))),
-            Err(e) => Err(Error::RequestError(Box::new(e))),
+            Err(e) => Err(Error::RequestError(e)),
         };
         progress_bar.finish_and_clear();
         result
@@ -224,36 +234,36 @@ impl<'a> Uploader<'a> {
     /// Delete the given file from the server.
     fn delete(&self, file: &'a str) -> Result<String> {
         let url = self.retrieve_url(file)?;
-        let mut request = self.client.delete(url.as_str());
+        let mut request = self
+            .client
+            .delete(url.as_str())
+            .config()
+            .http_status_as_error(false)
+            .build();
         if let Some(delete_token) = &self.config.server.delete_token {
-            request = request.set("Authorization", delete_token);
+            request = request.header("Authorization", delete_token);
         }
         let result = match request.call() {
             Ok(response) => {
                 let status = response.status();
-                let response_text = response.into_string()?;
-                if status == 200 {
+                let response_text = response.into_body().read_to_string()?;
+                if status.as_u16() == 200 {
                     Ok(response_text)
+                } else if status.as_u16() == 404 {
+                    Err(Error::DeleteError(response_text.trim().to_string()))
+                } else if status.is_client_error() || status.is_server_error() {
+                    Err(Error::DeleteError(format!(
+                        "{} (status code: {})",
+                        response_text.trim(),
+                        status.as_u16()
+                    )))
                 } else {
                     Err(Error::DeleteError(format!(
                         "unknown error (status code: {status})"
                     )))
                 }
             }
-            Err(UreqError::Status(code, response)) => {
-                if code == 404 {
-                    Err(Error::DeleteError(
-                        response.into_string()?.trim().to_string(),
-                    ))
-                } else {
-                    Err(Error::DeleteError(format!(
-                        "{} (status code: {})",
-                        response.into_string()?.trim(),
-                        code
-                    )))
-                }
-            }
-            Err(e) => Err(Error::RequestError(Box::new(e))),
+            Err(e) => Err(Error::RequestError(e)),
         };
         result
     }
@@ -273,12 +283,9 @@ impl<'a> Uploader<'a> {
         let url = self.retrieve_url("version")?;
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.set("Authorization", auth_token);
+            request = request.header("Authorization", auth_token);
         }
-        Ok(request
-            .call()
-            .map_err(|e| Error::RequestError(Box::new(e)))?
-            .into_string()?)
+        Ok(request.call()?.body_mut().read_to_string()?)
     }
 
     /// Retrieves and prints the files on server.
@@ -286,16 +293,14 @@ impl<'a> Uploader<'a> {
         let url = self.retrieve_url("list")?;
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.set("Authorization", auth_token);
+            request = request.header("Authorization", auth_token);
         }
-        let response = request
-            .call()
-            .map_err(|e| Error::RequestError(Box::new(e)))?;
+        let mut response = request.call()?;
         if !prettify {
-            writeln!(output, "{}", response.into_string()?)?;
+            writeln!(output, "{}", response.body_mut().read_to_string()?)?;
             return Ok(());
         }
-        let items: Vec<ListItem> = response.into_json()?;
+        let items: Vec<ListItem> = response.body_mut().read_json()?;
         if items.is_empty() {
             writeln!(output, "No files on server :(")?;
             return Ok(());
@@ -351,5 +356,117 @@ impl<'a> Uploader<'a> {
             )
         })?;
         Ok(())
+    }
+}
+
+#[cfg(feature = "use-native-certs")]
+fn native_root_certs() -> RootCerts {
+    let certs = rustls_native_certs::load_native_certs()
+        .certs
+        .iter()
+        .map(|cert| Certificate::from_der(cert.as_ref()).to_owned())
+        .collect::<Vec<_>>();
+    RootCerts::new_with_certs(&certs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread::{self, JoinHandle};
+
+    fn test_server(status: &str, body: &str) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+        let address = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("test server should have a local address")
+        );
+        let status = status.to_string();
+        let body = body.to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener
+                .accept()
+                .expect("test server should accept a request");
+            let mut request = Vec::new();
+            let mut buffer = [0; 1024];
+            let (header_len, content_len) = loop {
+                let bytes_read = stream
+                    .read(&mut buffer)
+                    .expect("test server should read request headers");
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if let Some(header_end) = request.windows(4).position(|v| v == b"\r\n\r\n") {
+                    let header_len = header_end + 4;
+                    let headers = String::from_utf8_lossy(&request[..header_len]);
+                    let content_len: usize = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("Content-Length: ")
+                                .or_else(|| line.strip_prefix("content-length: "))
+                        })
+                        .and_then(|value| value.parse().ok())
+                        .unwrap_or_default();
+                    break (header_len, content_len);
+                }
+            };
+            while request.len() < header_len + content_len {
+                let bytes_read = stream
+                    .read(&mut buffer)
+                    .expect("test server should read the request body");
+                request.extend_from_slice(&buffer[..bytes_read]);
+            }
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("test server should write the response");
+        });
+        (address, handle)
+    }
+
+    fn config(address: String) -> Config {
+        let mut config = Config::default();
+        config.server.address = address;
+        config
+    }
+
+    #[test]
+    fn upload_error_includes_response_body_and_status() {
+        let (address, server) = test_server("422 Unprocessable Content", "invalid upload\n");
+        let config = config(address);
+        let result = Uploader::new(&config).upload_stream("content".as_bytes()).1;
+
+        assert!(matches!(
+            result,
+            Err(Error::UploadError(message))
+                if message == "invalid upload (status code: 422)"
+        ));
+        server.join().expect("test server should stop cleanly");
+    }
+
+    #[test]
+    fn delete_not_found_uses_response_body() {
+        let (address, server) = test_server("404 Not Found", "file does not exist\n");
+        let config = config(address);
+        let result = Uploader::new(&config).delete_file("missing").1;
+
+        assert!(matches!(
+            result,
+            Err(Error::DeleteError(message)) if message == "file does not exist"
+        ));
+        server.join().expect("test server should stop cleanly");
+    }
+
+    #[test]
+    fn version_request_keeps_status_errors_enabled() {
+        let (address, server) = test_server("500 Internal Server Error", "failed\n");
+        let config = config(address);
+        let result = Uploader::new(&config).retrieve_version();
+
+        assert!(matches!(result, Err(Error::RequestError(_))));
+        server.join().expect("test server should stop cleanly");
     }
 }


### PR DESCRIPTION
## Summary

- upgrade ureq to 3.3.0 and move the native-certificate feature to the platform verifier
- preserve server response details for failed uploads and deletes
- cover status handling with local HTTP regression tests

## Why

ureq 3 no longer includes the response body in status errors. Upload and delete requests now disable status errors at request scope so the CLI can keep reporting the server message without changing status handling for version and list requests.

Closes #180.
Closes #223

## Validation

- `cargo test --all-features` — passed
- `cargo check --no-default-features` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed