### PR TITLE
refactor(config): mask authentication tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade ureq to 3.3.0
+- Store authentication and deletion tokens as masked secrets
 
 ## [0.9.5] - 2026-03-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "indicatif",
  "multipart",
  "rustls-native-certs",
+ "secrecy",
  "serde",
  "shellexpand",
  "thiserror 2.0.18",
@@ -751,6 +752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ use-native-certs = ["dep:rustls-native-certs"]
 
 [dependencies]
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
+secrecy = { version = "0.10.3", features = ["serde"] }
 toml = "1.1.2"
 thiserror = "2.0.18"
 getopts = "0.2.24"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
 use getopts::Options;
+use secrecy::SecretString;
 use std::env;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ pub struct Args {
     /// Server address.
     pub server: Option<String>,
     /// Authentication or delete token.
-    pub auth: Option<String>,
+    pub auth: Option<SecretString>,
     /// URL to shorten.
     pub url: Option<String>,
     /// Remote URL to download file.
@@ -115,7 +116,7 @@ impl Args {
                 .or_else(|| matches.opt_str("c"))
                 .map(PathBuf::from),
             server: matches.opt_str("s"),
-            auth: matches.opt_str("a"),
+            auth: matches.opt_str("a").map(Into::into),
             url: matches.opt_str("u"),
             remote: matches.opt_str("r"),
             oneshot: matches.opt_present("o"),
@@ -127,5 +128,23 @@ impl Args {
             filename: matches.opt_str("n"),
             files: matches.free,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_output_masks_auth_token() {
+        let args = Args {
+            auth: Some("cli-secret".into()),
+            ..Args::default()
+        };
+
+        let debug = format!("{args:?}");
+
+        assert!(!debug.contains("cli-secret"));
+        assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::args::Args;
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::fs;
 
@@ -18,14 +19,16 @@ pub struct Config {
 pub struct ServerConfig {
     /// Server address.
     pub address: String,
-    /// Token for authentication.
-    pub auth_token: Option<String>,
+    /// Token for authentication, omitted when serializing the configuration.
+    #[serde(skip_serializing)]
+    pub auth_token: Option<SecretString>,
     /// A file containing the token for authentication.
     ///
     /// Leading and trailing whitespace will be trimmed.
     pub auth_token_file: Option<String>,
-    /// Token for deleting files.
-    pub delete_token: Option<String>,
+    /// Token for deleting files, omitted when serializing the configuration.
+    #[serde(skip_serializing)]
+    pub delete_token: Option<SecretString>,
     /// A file containing the token for deleting files.
     ///
     /// Leading and trailing whitespace will be trimmed.
@@ -81,7 +84,7 @@ impl Config {
         if let Some(path) = &self.server.auth_token_file {
             let path = shellexpand::tilde(path).to_string();
             match fs::read_to_string(path) {
-                Ok(token) => self.server.auth_token = Some(token.trim().to_string()),
+                Ok(token) => self.server.auth_token = Some(token.trim().into()),
                 Err(e) => eprintln!("Error while reading token file: {e}"),
             };
         };
@@ -89,7 +92,7 @@ impl Config {
         if let Some(path) = &self.server.delete_token_file {
             let path = shellexpand::tilde(path).to_string();
             match fs::read_to_string(path) {
-                Ok(token) => self.server.delete_token = Some(token.trim().to_string()),
+                Ok(token) => self.server.delete_token = Some(token.trim().into()),
                 Err(e) => eprintln!("Error while reading token file: {e}"),
             };
         };
@@ -99,6 +102,31 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn debug_masks_and_serialization_omits_tokens() {
+        let cfg: Config = toml::from_str(
+            r#"
+                [server]
+                address = "https://paste.example.com"
+                auth_token = "auth-secret"
+                delete_token = "delete-secret"
+
+                [paste]
+            "#,
+        )
+        .expect("configuration should deserialize");
+
+        let debug = format!("{cfg:?}");
+        let serialized = toml::to_string(&cfg).expect("configuration should serialize");
+
+        for token in ["auth-secret", "delete-secret"] {
+            assert!(!debug.contains(token));
+            assert!(!serialized.contains(token));
+        }
+        assert!(debug.contains("[REDACTED]"));
+    }
 
     #[test]
     /// Test that the token file is being properly processed.
@@ -108,7 +136,13 @@ mod tests {
 
         cfg.server.auth_token_file = Some("tests/token_file_parsing/token.txt".to_string());
         cfg.parse_token_files();
-        assert_eq!(cfg.server.auth_token, Some(token));
+        assert_eq!(
+            cfg.server
+                .auth_token
+                .as_ref()
+                .map(|token| token.expose_secret()),
+            Some(token.as_str())
+        );
     }
 
     #[test]
@@ -120,6 +154,12 @@ mod tests {
         cfg.server.auth_token_file =
             Some("tests/token_file_parsing/token_whitespaced.txt".to_string());
         cfg.parse_token_files();
-        assert_eq!(cfg.server.auth_token, Some(token));
+        assert_eq!(
+            cfg.server
+                .auth_token
+                .as_ref()
+                .map(|token| token.expose_secret()),
+            Some(token.as_str())
+        );
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::error::{Error, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use multipart::client::lazy::Multipart;
+use secrecy::ExposeSecret;
 use serde::Deserialize;
 use std::io::{Read, Result as IoResult, Write};
 use std::time::Duration;
@@ -182,7 +183,7 @@ impl<'a> Uploader<'a> {
             request = request.header("Content-Length", content_len.to_string());
         }
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.header("Authorization", auth_token);
+            request = request.header("Authorization", auth_token.expose_secret());
         }
         if let Some(expiration_time) = &self.config.paste.expire {
             request = request.header(EXPIRATION_HEADER, expiration_time);
@@ -241,7 +242,7 @@ impl<'a> Uploader<'a> {
             .http_status_as_error(false)
             .build();
         if let Some(delete_token) = &self.config.server.delete_token {
-            request = request.header("Authorization", delete_token);
+            request = request.header("Authorization", delete_token.expose_secret());
         }
         let result = match request.call() {
             Ok(response) => {
@@ -283,7 +284,7 @@ impl<'a> Uploader<'a> {
         let url = self.retrieve_url("version")?;
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.header("Authorization", auth_token);
+            request = request.header("Authorization", auth_token.expose_secret());
         }
         Ok(request.call()?.body_mut().read_to_string()?)
     }
@@ -293,7 +294,7 @@ impl<'a> Uploader<'a> {
         let url = self.retrieve_url("list")?;
         let mut request = self.client.get(url.as_str());
         if let Some(auth_token) = &self.config.server.auth_token {
-            request = request.header("Authorization", auth_token);
+            request = request.header("Authorization", auth_token.expose_secret());
         }
         let mut response = request.call()?;
         if !prettify {
@@ -374,6 +375,7 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::mpsc::{self, Receiver};
     use std::thread::{self, JoinHandle};
 
     fn test_server(status: &str, body: &str) -> (String, JoinHandle<()>) {
@@ -427,6 +429,45 @@ mod tests {
         (address, handle)
     }
 
+    fn header_test_server(status: &str, body: &str) -> (String, Receiver<String>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+        let address = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("test server should have a local address")
+        );
+        let status = status.to_string();
+        let body = body.to_string();
+        let (request_tx, request_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener
+                .accept()
+                .expect("test server should accept a request");
+            let mut request = Vec::new();
+            let mut buffer = [0; 1024];
+            let headers = loop {
+                let bytes_read = stream
+                    .read(&mut buffer)
+                    .expect("test server should read request headers");
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if let Some(header_end) = request.windows(4).position(|v| v == b"\r\n\r\n") {
+                    break String::from_utf8_lossy(&request[..header_end + 4]).into_owned();
+                }
+            };
+            request_tx
+                .send(headers)
+                .expect("test should receive request headers");
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("test server should write the response");
+        });
+        (address, request_rx, handle)
+    }
+
     fn config(address: String) -> Config {
         let mut config = Config::default();
         config.server.address = address;
@@ -467,6 +508,40 @@ mod tests {
         let result = Uploader::new(&config).retrieve_version();
 
         assert!(matches!(result, Err(Error::RequestError(_))));
+        server.join().expect("test server should stop cleanly");
+    }
+
+    #[test]
+    fn version_request_sends_auth_token() {
+        let (address, request, server) = header_test_server("200 OK", "0.15.0\n");
+        let mut config = config(address);
+        config.server.auth_token = Some("auth-secret".into());
+
+        let result = Uploader::new(&config).retrieve_version();
+
+        assert!(result.is_ok(), "{result:?}");
+        assert!(request
+            .recv()
+            .expect("test should receive request headers")
+            .to_ascii_lowercase()
+            .contains("authorization: auth-secret"));
+        server.join().expect("test server should stop cleanly");
+    }
+
+    #[test]
+    fn delete_sends_delete_token() {
+        let (address, request, server) = header_test_server("200 OK", "deleted\n");
+        let mut config = config(address);
+        config.server.delete_token = Some("delete-secret".into());
+
+        let result = Uploader::new(&config).delete_file("file").1;
+
+        assert!(result.is_ok(), "{result:?}");
+        assert!(request
+            .recv()
+            .expect("test should receive request headers")
+            .to_ascii_lowercase()
+            .contains("authorization: delete-secret"));
         server.join().expect("test server should stop cleanly");
     }
 }


### PR DESCRIPTION
## Summary

- store CLI and configuration tokens in `SecretString`
- omit tokens from serialized configuration and expose them only for HTTP authorization
- cover debug masking and outbound authentication headers

## Why

`Args` and `Config` derive `Debug`, so storing tokens as plain strings can expose credentials in diagnostics. Closes #172.

## Validation

- `cargo test --all-features --locked`
- `cargo clippy --tests --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --no-default-features --locked`
- `cargo build --all-features --locked`
- `cargo machete`
