### PR TITLE
feat(cli): support protected files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ cargo build --release
 -V, --server-version retrieves the server version
 -l, --list           lists files on the server
 -d, --delete         delete files from server
+-P, --protected      upload a protected file
 -o, --oneshot        generates one shot links
 -p, --pretty         prettifies the output
 -c, --config CONFIG  sets the configuration file

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,6 +20,8 @@ pub struct Args {
     pub remote: Option<String>,
     /// Files to upload.
     pub files: Vec<String>,
+    /// Whether the file will be protected with a random password.
+    pub protected: bool,
     /// Whether if the file will disappear after being viewed once.
     pub oneshot: bool,
     /// Expiration time for the link.
@@ -45,6 +47,7 @@ impl Args {
         opts.optflag("V", "server-version", "retrieves the server version");
         opts.optflag("l", "list", "lists files on the server");
         opts.optflag("d", "delete", "delete files from server");
+        opts.optflag("P", "protected", "upload a protected file");
         opts.optflag("o", "oneshot", "generates one shot links");
         opts.optflag("p", "pretty", "prettifies the output");
         opts.optopt("c", "config", "sets the configuration file", "CONFIG");
@@ -119,6 +122,7 @@ impl Args {
             auth: matches.opt_str("a").map(Into::into),
             url: matches.opt_str("u"),
             remote: matches.opt_str("r"),
+            protected: matches.opt_present("P"),
             oneshot: matches.opt_present("o"),
             expire: matches.opt_str("e"),
             prettify: matches.opt_present("p"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,8 @@ pub struct ServerConfig {
 pub struct PasteConfig {
     /// Whether if the file will disappear after being viewed once.
     pub oneshot: Option<bool>,
+    /// Whether the file will be protected with a random password.
+    pub protected: Option<bool>,
     /// Expiration time for the link.
     pub expire: Option<String>,
     /// Filename.
@@ -68,6 +70,9 @@ impl Config {
         }
         if args.oneshot {
             self.paste.oneshot = Some(true);
+        }
+        if args.protected {
+            self.paste.protected = Some(true);
         }
         if args.expire.is_some() {
             self.paste.expire = args.expire.as_ref().cloned();

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -213,14 +213,10 @@ impl<'a> Uploader<'a> {
                         response_text.trim(),
                         status.as_u16()
                     )))
-                } else if !self.config.paste.protected.unwrap_or(false)
-                    && response_text.lines().count() != 1
-                {
-                    Err(Error::UploadError(format!(
-                        "server returned invalid body (status code: {status})"
-                    )))
-                } else if self.config.paste.protected.unwrap_or(false)
-                    && response_text.lines().count() != 2
+                } else if (!self.config.paste.protected.unwrap_or(false)
+                    && response_text.lines().count() != 1)
+                    || (self.config.paste.protected.unwrap_or(false)
+                        && response_text.lines().count() != 2)
                 {
                     Err(Error::UploadError(format!(
                         "server returned invalid body (status code: {status})"

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -113,6 +113,8 @@ impl<'a> Uploader<'a> {
     pub fn upload_file(&self, file: &'a str) -> UploadResult<'a, String> {
         let field = if self.config.paste.oneshot == Some(true) {
             "oneshot"
+        } else if self.config.paste.protected == Some(true) {
+            "protected"
         } else {
             "file"
         };
@@ -154,6 +156,8 @@ impl<'a> Uploader<'a> {
     pub fn upload_stream<S: Read>(&self, stream: S) -> UploadResult<'a, String> {
         let field = if self.config.paste.oneshot == Some(true) {
             "oneshot"
+        } else if self.config.paste.protected == Some(true) {
+            "protected"
         } else {
             "file"
         };
@@ -209,12 +213,28 @@ impl<'a> Uploader<'a> {
                         response_text.trim(),
                         status.as_u16()
                     )))
-                } else if response_text.lines().count() != 1 {
+                } else if !self.config.paste.protected.unwrap_or(false)
+                    && response_text.lines().count() != 1
+                {
+                    Err(Error::UploadError(format!(
+                        "server returned invalid body (status code: {status})"
+                    )))
+                } else if self.config.paste.protected.unwrap_or(false)
+                    && response_text.lines().count() != 2
+                {
                     Err(Error::UploadError(format!(
                         "server returned invalid body (status code: {status})"
                     )))
                 } else if status.as_u16() == 200 {
-                    Ok(response_text)
+                    let final_result = if response_text.lines().count() == 2 {
+                        response_text
+                            .split_once('\n')
+                            .map(|(first, second)| format!("{first} ({})", second.trim()))
+                            .unwrap_or(response_text)
+                    } else {
+                        response_text
+                    };
+                    Ok(final_result)
                 } else {
                     Err(Error::UploadError(format!(
                         "unknown error (status code: {status})"


### PR DESCRIPTION
This PR supports the upload of protected files.

```
$ rpaste -a atoken -s https://test.local/paste -p -P README.md
README.md => https://atvie01v.local/paste/README.Y1xh.md (Password: CZvMZl78LMoNrR4jQvz7dXu2)

$ rpaste -a atoken -s https://test.local/paste -P README.md
https://atvie01v.local/paste/README.P12a.md (Password: vdZihhnVIPWMZnw9WFRfp2D1)
```